### PR TITLE
themes: update onebar's link

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -540,7 +540,7 @@
   },
   {
     "title": "Firefox Onebar",
-    "link": "https://codeberg.org/Freeplay/Firefox-Onebar",
+    "link": "https://git.gay/freeplay/Firefox-Onebar",
     "description": "A single bar for Firefox's UI.",
     "image": "assets/img/themes/onebar.webp",
     "tags": [ "Freeplay", "oneline", "onebar", "compact", "minimal"]


### PR DESCRIPTION
I've moved Onebar's repo to https://git.gay/freeplay/Firefox-Onebar