### PR TITLE
themes.json: fix link of "FireFox OneLine Navbar"

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -848,7 +848,7 @@
   },
   {
     "title": "FireFox OneLine Navbar",
-    "link": "FawazBinSaleem/FireFoxOneLinerCSS",
+    "link": "https://github.com/FawazBinSaleem/FireFoxOneLinerCSS",
     "description": "A compact oneliner navbar css theme.",
     "image": "assets/img/themes/firefoxoneline.png",
     "tags": ["oneline", "black color", "amoled", "oneliner", "navbar", "One Line", "compact" ]


### PR DESCRIPTION
I opened an issue to add my theme but the link wasn't added properly,  it was missing 'https://github.com/', so I added it on my theme.